### PR TITLE
Add QA section on the stochastic parrots paper.

### DIFF
--- a/_episodes/04-bias.md
+++ b/_episodes/04-bias.md
@@ -82,17 +82,19 @@ When the models are trained on biased data - which they inevitably are - the mod
 
 ## Stochastic parrots 🦜
 
-On a surface level modern language models can give the appearance of possessing human-like intelligence, for example, by holding conversations or by creating poems.
+In their high-profile paper [On the Dangers of Stochastic Parrots: Can Language Models Be Too Big? 🦜](https://dl.acm.org/doi/pdf/10.1145/3442188.3445922), Bender and colleagues ask: "What are the possible risks associated with \[language model\] technology and what paths are available for mitigating those risks?". 
 
-In their paper [On the Dangers of Stochastic Parrots: Can Language Models Be Too Big? 🦜](https://dl.acm.org/doi/pdf/10.1145/3442188.3445922), Bender et al ask: "What are the possible risks associated with this technology and what paths are available for mitigating those risks?". 
+The last couple of paragraphs of the conclusion are copied below:
 
-The abstract is copied below:
+> Work on synthetic human behavior is a bright line in ethical AI development, where downstream effects need to be understood and modeled in order to block foreseeable harm to society and different social groups. Thus what is also needed is scholarship on the benefits, harms, and risks of mimicking humans and thoughtful design of target tasks grounded in use cases sufficiently concrete to allow collaborative design with affected communities.
 
-> The past 3 years of work in NLP have been characterized by the development and deployment of ever larger language models, especially for English. BERT, its variants, GPT-2/3, and others, most recently Switch-C, have pushed the boundaries of the possible both through architectural innovations and through sheer size. Using these pretrained models and the methodology of fine-tuning them for specific tasks, researchers have extended the state of the art on a wide array of tasks as measured by leaderboards on specific benchmarks for English. In this paper, we take a step back and ask: How big is too big? What are the possible risks associated with this technology and what paths are available for mitigating those risks? We provide recommendations including weighing the environmental and financial costs first, investing resources into curating and carefully documenting datasets rather than ingesting everything on the web, carrying out pre-development exercises evaluating how the planned approach fits into research and development goals and supports stakeholder values, and encouraging research directions beyond ever larger language models.
-
-In summarizing paths forward for research, they suggest:
-
-> In summary, we advocate for research that centers the people who stand to be adversely affected by the resulting technology, with a broad view on the possible ways that technology can affect people. This, in turn, means making time in the research process for considering environmental impacts, for doing careful data curation and documentation, for engaging with stakeholders early in the design process, for exploring multiple possible paths towards longterm goals, for keeping alert to dual-use scenarios, and finally for allocating research effort to harm mitigation in such cases.
+> ## Question
+> A) Why is the word "parrot" used to describe the language models?
+> 
+> > ## Answer
+> > A) On a surface level modern language models can give the appearance of possessing human-like intelligence, for example, by holding conversations or by creating poems. In reality, the models are simply mimicking the language and biases of humans.
+> {: .solution}
+{: .challenge}
 
 <!--
 


### PR DESCRIPTION
Currently [the bias section](https://carpentries-incubator.github.io/machine-learning-responsible-python/04-bias/index.html) highlights the [Stochastic Parrots paper](https://dl.acm.org/doi/pdf/10.1145/3442188.3445922), but there is no directed discussion. This pull requests add the QA section and a question. Additional questions/answers would be an improvement.
